### PR TITLE
Use suspense for Next.js component to avoid client-side rendering

### DIFF
--- a/packages/web/src/nextjs/index.tsx
+++ b/packages/web/src/nextjs/index.tsx
@@ -1,12 +1,20 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { SpeedInsights as SpeedInsightsScript } from '../react';
 import type { SpeedInsightsProps } from '../types';
 import { useRoute } from './utils';
 
-export function SpeedInsights(
-  props: Omit<SpeedInsightsProps, 'route'>,
-): JSX.Element {
+type Props = Omit<SpeedInsightsProps, 'route'>;
+
+function SpeedInsightsComponent(props: Props): React.ReactElement {
   const route = useRoute();
 
   return <SpeedInsightsScript route={route} {...props} framework="next" />;
+}
+
+export function SpeedInsights(props: Props): React.ReactElement {
+  return (
+    <Suspense fallback={null}>
+      <SpeedInsightsComponent {...props} />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
### 📓 What's in there?

we caused an issue that nextjs.org opted to client-side rendering only because we're using `useSearchParams` hook which does client-side rendering until the next `Suspense` boundary.

Wrap our component in `Suspense` to avoid that
