### PR TITLE
feat: shorter framework names

### DIFF
--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -1,10 +1,11 @@
-import { name as packageName, version } from '../package.json';
+import { version } from '../package.json';
 import { initQueue } from './queue';
 import type { SpeedInsightsProps } from './types';
 import { isBrowser, isDevelopment } from './utils';
 
 const DEV_SCRIPT_URL = `https://va.vercel-scripts.com/v1/speed-insights/script.debug.js`;
 const SCRIPT_URL = `/_vercel/speed-insights/script.js`;
+const packageName = 'vercel';
 
 /**
  * Injects the Vercel Speed Insights script into the page head and starts tracking page views. Read more in our [documentation](https://vercel.com/docs/speed-insights).


### PR DESCRIPTION
### 📓 What's in there?

When reporting vitals and metrics, we should use a shorter framework name to avoid very long values like `@vercel/speed-insights/sveltekit`

A shorter prefix like `vercel` should be enough, and will give `vercel/next`, `vercel/sveltekit` or `vercel/nuxt`

### 🧪 How to test?

Have a try at one of our deployments, with dev tools open on network, filtering for `vitals`
<img width="1779" alt="image" src="https://github.com/vercel/speed-insights/assets/186268/3475a4fd-145a-4339-aa6e-629345280629">

