### PR TITLE
fix: astro check fails on @vercel/speed-insights/astro missing types

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/speed-insights",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Speed Insights is a tool for measuring web performance and providing suggestions for improvement.",
   "keywords": [
     "speed-insights",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,7 +19,8 @@
       "require": "./dist/index.js"
     },
     "./astro": {
-      "import": "./dist/astro/index.astro"
+      "import": "./dist/astro/index.astro",
+      "types": "./dist/astro/index.astro.tsx"
     },
     "./next": {
       "browser": "./dist/next/index.mjs",

--- a/packages/web/src/astro/index.astro
+++ b/packages/web/src/astro/index.astro
@@ -3,7 +3,6 @@
 import type { SpeedInsightsProps } from '../index.d.ts';
 type Props = Omit<SpeedInsightsProps, 'framework' | 'beforeSend'>;
 
-// beforeSend?
 const propsStr = JSON.stringify(Astro.props);
 const paramsStr = JSON.stringify(Astro.params);
 ---
@@ -25,11 +24,11 @@ const paramsStr = JSON.stringify(Astro.params);
           const props = JSON.parse(this.dataset.props ?? '{}');
           const params = JSON.parse(this.dataset.params ?? '{}');
           const route = computeRoute(this.dataset.pathname ?? '', params);
-          injectSpeedInsights({ 
-            route, 
-            ...props, 
+          injectSpeedInsights({
+            route,
+            ...props,
             framework: 'astro',
-            beforeSend: window.speedInsightsBeforeSend
+            beforeSend: window.speedInsightsBeforeSend,
           });
         } catch (err) {
           throw new Error(`Failed to parse SpeedInsights properties: ${err}`);

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -39,6 +39,8 @@ declare global {
     siq?: SpeedInsights['queue'];
 
     sil?: boolean;
-    // vam?: Mode;
+
+    /** used by Astro component only */
+    speedInsightsBeforeSend?: BeforeSendMiddleware;
   }
 }


### PR DESCRIPTION
### 📓 What's in there?

Fixes #36. It is not possible yet to publish types along an Astro component, and the `astro check` command will fail on it.
As per the Astro team [recommendations](https://vercel.slack.com/archives/C02F244PX6Y/p1705332194344439?thread_ts=1705327998.713399&cid=C02F244PX6Y), we need to specify a file for types, even if it does not exist.

### 🧪 How to test?

1. once the code got retrieved locally, build the whole package: `pnpm -F @vercel/speed-insights build`
1. then go to the astro example app `cd apps/astro`
1. install typescript and the check command: `pnpm i -D typescript @astrojs/check`
1. run it: `pnpm exec astro check`: it will work, while it used to fail with error:
   ```shell
   src/components/BaseHead.astro:5:27 - error ts(2307): Cannot find module '@vercel/speed-insights/astro' or its corresponding type declarations.
   
   5 import SpeedInsights from '@vercel/speed-insights/astro';
   ```

Note: there is still a warning about `speedInsightsBeforeSend()` unused function, but I couldn't get rid of it.
