### PR TITLE
Only return `route` if params is not `null`

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/speed-insights",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Speed Insights is a tool for measuring web performance and providing suggestions for improvement.",
   "keywords": [
     "speed-insights",

--- a/packages/web/src/nextjs/utils.ts
+++ b/packages/web/src/nextjs/utils.ts
@@ -1,4 +1,5 @@
 'use client';
+/* eslint-disable @typescript-eslint/no-unnecessary-condition -- can be empty in pages router */
 import { useParams, usePathname, useSearchParams } from 'next/navigation.js';
 import { computeRoute } from '../utils';
 
@@ -9,9 +10,8 @@ export const useRoute = (): string | null => {
 
   const finalParams = {
     ...Object.fromEntries(searchParams.entries()),
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- can be empty in pages router
     ...(params || {}),
   };
 
-  return computeRoute(path, finalParams);
+  return params ? computeRoute(path, finalParams) : null;
 };


### PR DESCRIPTION
### 📓 What's in there?

We should only return the generated `route` if the `params` are not `null`