### PR TITLE
fix(#56,#72): useSearchParams might return null and break script insertion

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/speed-insights",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Speed Insights is a tool for measuring web performance and providing suggestions for improvement.",
   "keywords": [
     "speed-insights",

--- a/packages/web/src/nextjs/utils.ts
+++ b/packages/web/src/nextjs/utils.ts
@@ -5,7 +5,7 @@ import { computeRoute } from '../utils';
 
 export const useRoute = (): string | null => {
   const params = useParams();
-  const searchParams = useSearchParams();
+  const searchParams = useSearchParams() || new URLSearchParams();
   const path = usePathname();
 
   const finalParams = {


### PR DESCRIPTION
### 📓 What's in there?

Under some circumstances with pages router (some Next.js versions, env variable or depending on where the component is mounted), the following error is thrown when rendering `SpeedInsights` Next.js component:

```
TypeError: searchParams.entries is not a function
    at useRoute (file:///node_modules/.pnpm/@vercel+speed-insights@1.0.11_next@14.2.3_react@18.3.1/node_modules/@vercel/speed-insights/dist/next/index.mjs:151:40)
    at SpeedInsightsComponent (file:///node_modules/.pnpm/@vercel+speed-insights@1.0.11_next@14.2.3_react@18.3.1/node_modules/@vercel/speed-insights/dist/next/index.mjs:159:17)
    at renderWithHooks (/node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5658:16)
    at renderIndeterminateComponent (/node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5732:1
```

This PR fixes it, but providing a default empty search param object.

### 🧪 How to test?

Tested with:
- Next.js@14.2.3
- pages router
- component mounted in `pages/_document.tsx`

<!--
### ❗ Notes to reviewers

  ✍️ You can provide more technical/design details about your change
-->
