### PR TITLE
Make access defensive and fix environment variable reference.

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/speed-insights",
-  "version": "1.2.0-canary.1",
+  "version": "1.2.0-canary.2",
   "description": "Speed Insights is a tool for measuring web performance and providing suggestions for improvement.",
   "keywords": [
     "speed-insights",

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -58,7 +58,8 @@ function injectSpeedInsights(
   }
   if (props.endpoint) {
     script.dataset.endpoint = props.endpoint;
-  } else if (process.env[basepathVariableName]) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process doesn't exist in all frameworks
+  } else if (process?.env?.[basepathVariableName]) {
     script.dataset.endpoint = `/${process.env[basepathVariableName]}/_vercel/speed-insights/vitals`;
   }
   if (props.dsn) {

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -7,7 +7,6 @@ const SCRIPT_URL = 'https://va.vercel-scripts.com/v1/speed-insights';
 const PROD_SCRIPT_URL = `${SCRIPT_URL}/script.js`;
 const DEV_SCRIPT_URL = `${SCRIPT_URL}/script.debug.js`;
 const PROXY_SCRIPT_URL = '/_vercel/speed-insights/script.js';
-const basepathVariableName = 'NEXT_PUBLIC_SPEED_INSIGHTS_BASEPATH';
 
 /**
  * Injects the Vercel Speed Insights script into the page head and starts tracking page views. Read more in our [documentation](https://vercel.com/docs/speed-insights).
@@ -62,9 +61,9 @@ function injectSpeedInsights(
     // eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- process doesn't exist in all frameworks
     typeof process !== 'undefined' &&
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process doesn't exist in all frameworks
-    process.env?.[basepathVariableName]
+    process.env?.NEXT_PUBLIC_SPEED_INSIGHTS_BASEPATH
   ) {
-    script.dataset.endpoint = `/${process.env[basepathVariableName]}/_vercel/speed-insights/vitals`;
+    script.dataset.endpoint = `/${process.env.NEXT_PUBLIC_SPEED_INSIGHTS_BASEPATH}/_vercel/speed-insights/vitals`;
   }
   if (props.dsn) {
     script.dataset.dsn = props.dsn;

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -58,8 +58,11 @@ function injectSpeedInsights(
   }
   if (props.endpoint) {
     script.dataset.endpoint = props.endpoint;
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process doesn't exist in all frameworks
-  } else if (process?.env?.[basepathVariableName]) {
+    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain, @typescript-eslint/no-unnecessary-condition -- process doesn't exist in all frameworks
+  } else if (
+    typeof process !== 'undefined' &&
+    process.env?.[basepathVariableName]
+  ) {
     script.dataset.endpoint = `/${process.env[basepathVariableName]}/_vercel/speed-insights/vitals`;
   }
   if (props.dsn) {

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -58,9 +58,10 @@ function injectSpeedInsights(
   }
   if (props.endpoint) {
     script.dataset.endpoint = props.endpoint;
-    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain, @typescript-eslint/no-unnecessary-condition -- process doesn't exist in all frameworks
   } else if (
+    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- process doesn't exist in all frameworks
     typeof process !== 'undefined' &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process doesn't exist in all frameworks
     process.env?.[basepathVariableName]
   ) {
     script.dataset.endpoint = `/${process.env[basepathVariableName]}/_vercel/speed-insights/vitals`;


### PR DESCRIPTION
`process` may not exist in all frameworks, this ensures things will continue to work as expected.

`process.env[someVar]` works in dev mode but not production, so this switches to `process.env.NEXT_PUBLIC_...`.

### 📓 What's in there?

<!--
  ✍️ Please explain what this PR contains and why.
  If not done automatically, refer to any issues, PRs or stories.
-->

### 🧪 How to test?

<!--
  ✍️ Help your reviewer testing your feature by providing simple instructions:
  - do X
     > expect A
  - do Y
     > expect B. It used to be C
-->

<!--
### ❗ Notes to reviewers

  ✍️ You can provide more technical/design details about your change
-->
