### PR TITLE
fix: a.useParams is not a function in next app

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/speed-insights",
-  "version": "1.2.0-canary.2",
+  "version": "1.2.0-canary.3",
   "description": "Speed Insights is a tool for measuring web performance and providing suggestions for improvement.",
   "keywords": [
     "speed-insights",

--- a/packages/web/src/nextjs/index.tsx
+++ b/packages/web/src/nextjs/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Suspense } from 'react';
 import { SpeedInsights as SpeedInsightsScript } from '../react';
 import type { SpeedInsightsProps } from '../types';

--- a/packages/web/src/react/index.tsx
+++ b/packages/web/src/react/index.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { useEffect, useRef } from 'react';
 import type { SpeedInsightsProps } from '../types';
 import { computeRoute, injectSpeedInsights } from '../generic';


### PR DESCRIPTION
### 📓 What's in there?

@emspishak found an issue with the next component.
It's very likely because I forgot to report `use client` into the component file itself.

### 🧪 How to test?

I'll release canary.3 and I'll test it on Eric's branch.
