### PR TITLE
feat: add warm-up script function to fetch resources before injection

### DIFF
--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -4,6 +4,18 @@ import type { SpeedInsightsProps, BeforeSendMiddleware } from './types';
 import { computeRoute, getScriptSrc, isBrowser, isDevelopment } from './utils';
 
 /**
+ * Triggers a fetch call to the specified URL to warm up the endpoint.
+ * Any errors are silently ignored.
+ */
+async function warmUpScript(src: string): Promise<void> {
+  try {
+    await fetch(src);
+  } catch (err) {
+    void 0; // no-op to satisfy non-empty block rules
+  }
+}
+
+/**
  * Injects the Vercel Speed Insights script into the page head and starts tracking page views. Read more in our [documentation](https://vercel.com/docs/speed-insights).
  * @param [props] - Speed Insights options.
  * @param [props.debug] - Whether to enable debug logging in development. Defaults to `true`.
@@ -65,7 +77,9 @@ function injectSpeedInsights(
     );
   };
 
-  document.head.appendChild(script);
+  void warmUpScript(src).finally(() => {
+    document.head.appendChild(script);
+  });
 
   return {
     setRoute: (route: string | null): void => {


### PR DESCRIPTION
### 📓 What's in there?

This PR improves the script injection process for Vercel Speed Insights by adding a warm-up function. Before injecting the main script, the code performs a fetch to the script URL to "warm up" the endpoint (even if the first response might be HTML). This change is intended to reduce errors related to cold starts, ensuring that when the actual script is loaded, the endpoint is ready to serve valid JavaScript.

Issue https://github.com/vercel/speed-insights/issues/98

### 🧪 How to test?

Open a page that uses Speed Insights injection.

Verify that the script tag is appended to the document head after the warm-up call.


### ❗ Notes to reviewers

This change is purely additive and does not affect the core functionality of Speed Insights.

Please verify that this approach reduces errors associated with cold starts without introducing side effects in both development and production environments.
