### PR TITLE
fix: add route param to beforeSend event type

### DIFF
--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -14,6 +14,7 @@ export type EventTypes = 'vital';
 export interface Event {
   type: EventTypes;
   url: string;
+  route?: string;
 }
 
 export type BeforeSendMiddleware = (


### PR DESCRIPTION
### 📓 What's in there?

The event object sent to beforeSend contains the route (when available), but it is missing from the type.

### 🧪 How to test?

<!--
  ✍️ Help your reviewer testing your feature by providing simple instructions:
  - do X
     > expect A
  - do Y
     > expect B. It used to be C
-->

<!--
### ❗ Notes to reviewers

  ✍️ You can provide more technical/design details about your change
-->
