### PR TITLE
fix(ci): use OIDC trusted publishing for npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -20,9 +23,5 @@ jobs:
         run: pnpm -F @vercel/speed-insights build
       - run: pnpm -F @vercel/speed-insights publish --tag beta --no-git-checks
         if: github.event.release.prerelease == true
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
       - run: pnpm -F @vercel/speed-insights publish --no-git-checks
         if: github.event.release.prerelease == false
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,6 +11,9 @@
     "directory": "packages/web"
   },
   "license": "Apache-2.0",
+  "publishConfig": {
+    "provenance": true
+  },
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
## Why

`NPM_TOKEN_ELEVATED` can no longer be used (permissions revoked), so publishing is currently broken. This switches `@vercel/speed-insights` to OIDC trusted publishing, mirroring [vercel/analytics#203](https://github.com/vercel/analytics/pull/203).

## What

- **Grant `id-token: write`** on the release job so the runner can mint an OIDC token. The job previously had no permissions block, inheriting the default that blocks ID-token issuance.
- **Remove `NODE_AUTH_TOKEN`** from both publish steps. `pnpm@11.1.3` (already pinned) performs the OIDC token exchange natively.
- **Configure provenance via `publishConfig`** so it always applies, regardless of how publish is invoked.

The workflow keeps its existing trigger (`release: [published]`) and its beta/stable split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)