### PR TITLE
docs: fix separate typo in astro style comment

### DIFF
--- a/apps/astro/src/styles/global.css
+++ b/apps/astro/src/styles/global.css
@@ -149,6 +149,6 @@ hr {
   clip: rect(1px 1px 1px 1px);
   /* modern browsers, clip-path works inwards from each corner */
   clip-path: inset(50%);
-  /* added line to stop words getting smushed together (as they go onto seperate lines and some screen readers do not understand line feeds as a space */
+/* added line to stop words getting smushed together (as they go onto separate lines and some screen readers do not understand line feeds as a space */
   white-space: nowrap;
 }


### PR DESCRIPTION
Fixes `seperate` to `separate` in the Astro demo style comment. Comment-only change.